### PR TITLE
DM-17752:  fixed jupyter widgets reloading 

### DIFF
--- a/jupyter_firefly_extensions/_version.py
+++ b/jupyter_firefly_extensions/_version.py
@@ -5,6 +5,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-version_info = (0, 2, 2)
+version_info = (0, 2, 3)
 __version__ = ".".join(map(str, version_info))
 version_short = ".".join(map(str,version_info[0:3]))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter_firefly_extensions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A package for rendering FITS in Jupyter",
   "author": "Trey Roby <roby@ipac.caltech.edu>",
   "main": "lib/lab_extension.js",

--- a/src/SlateWidget.js
+++ b/src/SlateWidget.js
@@ -18,6 +18,8 @@ export const SlateModel = widgets.DOMWidgetModel.extend({
 
 var seq = 1;
 
+const divMap= {};
+
 // Custom View. Renders the widget model.
 export const SlateView= widgets.DOMWidgetView.extend({
     render() {
@@ -74,6 +76,15 @@ export const SlateView= widgets.DOMWidgetView.extend({
         };
         action.dispatchApiToolsView(true,false);
         this.controlApp= util.startAsAppFromApi(id, props, {});
+        divMap[id]= {controlApp:this.controlApp, renderTreeId};
+
+        Object.keys(divMap).forEach( (k) => {
+            if (k!==id && !window.document.getElementById(k) && divMap[k]) {
+               divMap[k].controlApp.unrender();
+               divMap[k]= undefined;
+            }
+
+        });
     }
 
 


### PR DESCRIPTION
fixed jupyter widgets reloading and not being able to replot an image

_to test:_

Execute slate-widget-demo.ipynb that is one of the examples for the extension. Run all the cells once; then restart the Python kernel for that notebook; then re-execute. Image should display both times.