### PR TITLE
Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 dist/
 *.iml
 lib/
+**/.ipynb_checkpoints/
 
 # Compiled javascript
 jupyter_fits_viewer/__pycache__/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This extension adds the following features to JupyterLab:
 
 ## Prerequisites
 
-* JupyterLab ^0.35.1
+* JupyterLab ^0.35.1,<4
 * nodejs
 * astropy ^3.0.0
 * firefly_client ^2.1.1
@@ -60,8 +60,13 @@ _Or_
 ### Install
 
 ```bash
+# install firefly_client package required to communicate with a firefly server from python
 pip install firefly_client
+
+# install client-side component of this extension from npm and enable it
 jupyter labextension install jupyter_firefly_extensions
+
+# install server-side component of this extension from pypi and enable the server extension manually
 pip install jupyter_firefly_extensions
 jupyter serverextension enable --py jupyter_firefly_extensions
 ```
@@ -78,8 +83,12 @@ _Then:_
 ```bash
 git clone https://github.com/Caltech-IPAC/jupyter_firefly_extensions
 cd jupyter_firefly_extensions
+
+# client-side component
 jupyter labextension install . --no-build
-jupyter lab build
+jupyter lab build  # required because using source extension
+
+# server-side component
 pip install -e .
 jupyter serverextension enable --py jupyter_firefly_extensions
 ```
@@ -107,4 +116,12 @@ The `examples` directory has several example notebooks to demonstrate the extens
 
  - `slate-demo-explicit.ipynb`, `slate-demo-explicit2.ipynb` - demonstrates
     opening a Firefly tab and sending data to it with the `FireflyClient` python API
- - `slate-widget-demo.ipnb` - simple demo of the Firefly slate widget
+ - Other notebooks demonstrate capabilites of widgets which are no longer supported, so they won't work.
+
+
+Besides this, you can also use this extension to display fits images. In the file browser of jupyter lab, simply clicking on a `.fits`  file will show the image in a new tab.
+
+
+
+### Troubleshooting
+If you are using a local Firefly server and facing issues with rendering images, check the console for an error message about being unable to load 'firefly-thread.worker.js'. If that's the case, you can clean your existing Firefly build using `gradle clean` and then build and deploy it in the development environment (instead of the local one, i.e., the default) by using `gradle -Penv=dev firefly:bAD`. Then, reload the Jupyter Lab browser tab (and empty the cache). You shouldn't see that console error anymore and the images should render correctly.

--- a/examples/slate-demo-explicit.ipynb
+++ b/examples/slate-demo-explicit.ipynb
@@ -21,22 +21,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import print_function, division, absolute_import"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Imports for firefly_client"
    ]
   },
@@ -368,12 +352,19 @@
     "             initZoomLevel=2, SurveyKey='asky', SurveyKeyBand='k',\n",
     "             WorldPt='10.68479;41.26906;EQ_J2000', SizeInDeg='.12')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -387,9 +378,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/slate-demo-explicit2.ipynb
+++ b/examples/slate-demo-explicit2.ipynb
@@ -21,14 +21,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imports for Python 2/3 compatibility\n",
     "Imports for firefly_client\n",
     "\n",
     "This example uses http://127.0.0.1:8080/firefly as the server.\n",
     "\n",
     "'slate.html' is a template made for grid view.\n",
     "\n",
-    "Open a browser to the firefly server in a new tab. Only works when running the notebook locally."
+    "You can also set `start_browser_tab=True` (default is `False`) to open the firefly server in a new browser tab (instead of a lab tab). Although, it only works when running the notebook locally."
    ]
   },
   {
@@ -37,11 +36,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function, division, absolute_import\n",
     "from firefly_client import FireflyClient\n",
     "import astropy.utils.data\n",
     "\n",
-    "fc = FireflyClient.make_lab_client(start_browser_tab=False)\n"
+    "fc = FireflyClient.make_lab_client(start_browser_tab=False)"
    ]
   },
   {
@@ -95,8 +93,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "\n",
     "# Add table in cell 'main'. \n",
     "# 'main' is the cell id currently supported by Firefly for element type 'tables'\n",
     "# this cell is shown at row = 0, col = 4 with width = 2, height = 2\n",
@@ -296,12 +292,19 @@
     "        \n",
     "    fc.show_fits_3color(threeC, viewer_id=viewer_id)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -315,9 +318,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- Added following to readme:
  - supports jupyter lab < 4 (tested works with latest minor version of v3 (3.6) but not with any of v4)
  - more explaination to installation steps
  - remove slate-widget from example coz no longer supported like other widgets
  - how to use it to display fits files
  - troubleshooting for firefly-thread.worker problem

- removed python 2 compatiblity changes from notebooks 

- gitignore notebook checkpoints