### PR TITLE
FIREFLY-1348: Fix missing/misplaced logo when using IRSAViewer

### DIFF
--- a/src/SlateCommandExt.js
+++ b/src/SlateCommandExt.js
@@ -110,11 +110,11 @@ export class SlateRootWidget extends Widget {
         this.title.label= 'Firefly: '+ id;
         this.title.closable= true;
         findFirefly().then( (ffConfig) => {
-            this.startViewer(ffConfig.firefly,id);
+            this.startViewer(ffConfig.firefly, id, ffConfig.fireflyURL);
         } );
     }
 
-    startViewer(firefly, id) {
+    startViewer(firefly, id, fireflyURL) {
         const {util,action}= firefly;
         const props=  {
             div: id,
@@ -131,6 +131,13 @@ export class SlateRootWidget extends Widget {
         ];
         if (!firefly.originalAppProps) {
             props.menu= fallbackMenu;
+        }
+        if (fireflyURL.endsWith('irsaviewer')) {
+            // make icon file path absolute, otherwise it won't be found
+            const originalAppIconProp = firefly?.originalAppProps?.appIcon;
+            if (originalAppIconProp) props.appIcon = fireflyURL + '/' + originalAppIconProp;
+            // resize it to fit in its parent container
+            props.bannerLeftStyle = {display: 'flex', marginTop: 'unset'};
         }
         action.dispatchApiToolsView(true,false);
         this.controlApp= util.startAsAppFromApi(id, props);


### PR DESCRIPTION
Fixes [FIREFLY-1348](https://jira.ipac.caltech.edu/browse/FIREFLY-1348)

## Testing
Checkout this branch locally and make sure that you have [development installation of firefly extension](https://github.com/Caltech-IPAC/jupyter_firefly_extensions?tab=readme-ov-file#development-install) in your python environment. (If you previously installed jupyter lab in development mode then you just need to run last command jlpm run build). 

Now set `FIREFLY_URL` environment variable as ipac or locally hosted irsaviewer before opening jupyter lab. Open firefly through launcher or example notebook, it should show firefly icon on the top-right resized to banner.