### PR TITLE
FIREFLY-1460: Use ServerConnection instead of fetch and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ These extensions add the following features to JupyterLab:
 
 * nodejs ^18.0.0 - only needed if you're doing [development install](#development-install)
 
+If you have conda installed and are setting up a fresh environment, you can use:
+```bash
+conda create -n jl-ff-ext -c conda-forge python jupyterlab firefly_client astropy
+conda activate jl-ff-ext
+```
+
 
 ### _Very Important_: first setup the Firefly URL - 3 ways
 
- * Add the following line to your `~/.jupyter/jupyter_notebook_config.py`
+You must provide **URL to a Firefly server** before running jupyter_firefly_extensions using ANY of the following ways:
+
+ * Add the following line to your `~/.jupyter/jupyter_config.py`
 
    ```python
    c.Firefly.url = 'http://localhost:8080/firefly'
@@ -36,7 +44,7 @@ These extensions add the following features to JupyterLab:
 
 _Or_
 
- * Add the following line to your `~/.jupyter/jupyter_notebook_config.json` under the root object.
+ * Add the following line to your `~/.jupyter/jupyter_config.json` under the root object.
 
    ```json
    "Firefly": {
@@ -58,11 +66,13 @@ _Or_
       setenv FIREFLY_URL http://localhost:8080/firefly
       ```
 
-**where the URL points to a Firefly server.**
-
+_Note:_ If your configuration is set in more than one way as described above, precedence order is:
+environment variable > jupyter_config.json > jupyter_config.py
 
 
 ## Installation
+
+In your environment with the prerequisites met,
 
 ```bash
 pip install jupyter_firefly_extensions
@@ -95,8 +105,11 @@ jupyter labextension develop . --overwrite
 # Enable the server extension
 jupyter server extension enable jupyter_firefly_extensions
 
-# Rebuild extension TS/JS source each time you make a change
+# Build extension TS/JS source
 jlpm run build
+
+# Alternatively, watch TS/JS source so that changes in it reflect automatically on lab
+jlpm watch
 ```
 
 

--- a/jupyter_firefly_extensions/handlers.py
+++ b/jupyter_firefly_extensions/handlers.py
@@ -105,7 +105,7 @@ def setup_handlers(server_app):
     """
     global firefly_config
     web_app = server_app.web_app
-    config_url = server_app.config.get('Firefly', {}).get('url', '')
+    config_url = server_app.config.get('Firefly', {}).get('url', 'http://localhost:8080/firefly')
     url = None
     if 'FIREFLY_URL' in os.environ:
         url = os.environ['FIREFLY_URL']

--- a/src/FireflyCommonUtils.js
+++ b/src/FireflyCommonUtils.js
@@ -1,4 +1,5 @@
 import {initFirefly} from 'firefly-api-access';
+import { ServerConnection } from '@jupyterlab/services';
 
 
 let cachedLoc;
@@ -21,13 +22,16 @@ export async function findFirefly()  {
     if (cachedFindFireflyResult) return cachedFindFireflyResult;
 
     try {
-        if (!cachedLoc) cachedLoc= await (await fetch(ffLocURL, fetchOptions)).json();
+        const settings = ServerConnection.makeSettings();
+        console.log(ffLocURL, settings);
+        if (!cachedLoc) cachedLoc= await (await ServerConnection.makeRequest(ffLocURL, fetchOptions, settings)).json();
 
         const {fireflyURL='http://localhost:8080/firefly', fireflyChannel:channel}= cachedLoc;
         if (!window.firefly?.initialized) window.firefly= {...window.firefly, wsch:channel};
         if (!window.getFireflyAPI) window.getFireflyAPI= initFirefly(fireflyURL);
         const firefly= await window.getFireflyAPI();
         cachedFindFireflyResult= {fireflyURL, channel, firefly};
+        console.log(cachedFindFireflyResult);
         return cachedFindFireflyResult;
     }
     catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,11 +4972,11 @@ __metadata:
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes [FIREFLY-1460](https://jira.ipac.caltech.edu/browse/FIREFLY-1460)

- Replaced `fetch` with `ServerConnection.makeRequest` to resolve XSRF issue observed at RSP
- Updated yarn.lock - TS was throwing "not found" when building extension source (I just did yarn install and it updated checksum)

Additional changes in src/FireflyCommonUtils.js:
- Moved fallback value of FIREFLY_URL from extension's client-side code to server-side code (handlers.py) because after resolving it from config, server stores the value in environment variable which is used by firefly_client in notebooks. So it was causing mismatch between client and server (firefly was loaded in lab, but not when `FireflyClient.make_lab_client()` executes in notebook)
- Added an explicit error when FIREFLY_URL is not valid because even if request from python server is resolved, FIREFLY_URL can be undefined or empty string in some cases, which was getting passed to `initFirefly()` and was throwing not-so-helpful errors.
- Added `throw e` at end of catch because it was resolving promise with `undefined`
- Added some documentation in code for clarity

## Testing
RSP already tested it but you can test it locally, by checking out this branch and then following instructions in README - I updated it to make it easy to setup a fresh environment.