### PR TITLE
FIREFLY-1348: Adjust appIcon when irsaviewer is used

### DIFF
--- a/src/SlateCommandExt.js
+++ b/src/SlateCommandExt.js
@@ -3,6 +3,7 @@ import { ICommandPalette } from '@jupyterlab/apputils';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { ILauncher } from '@jupyterlab/launcher';
 import { LabIcon } from '@jupyterlab/ui-components';
+import { set } from 'lodash';
 
 import { findFirefly } from './FireflyCommonUtils.js';
 import fireflyIconStr from '../style/fftools-logo.svg';
@@ -110,11 +111,10 @@ export class SlateRootWidget extends Widget {
             props.menu= fallbackMenu;
         }
         if (fireflyURL.endsWith('irsaviewer')) {
-            // make icon file path absolute, otherwise it won't be found
-            const originalAppIconProp = firefly?.originalAppProps?.appIcon;
-            if (originalAppIconProp) props.appIcon = fireflyURL + '/' + originalAppIconProp;
-            // resize it to fit in its parent container
-            props.bannerLeftStyle = {display: 'flex', marginTop: 'unset'};
+            // unset the appIcon styles that irsaviewer applies for its double banner layout
+            set(props,'slotProps.banner.slotProps.tabs.pl', 0);
+            set(props,'slotProps.banner.slotProps.icon.style.marginTop', 0);
+            set(props,'slotProps.banner.slotProps.icon.sx.height', 40);
         }
         action.dispatchApiToolsView(true,false);
         this.controlApp= util.startAsAppFromApi(id, props);


### PR DESCRIPTION
FIREFLY-1348 introduced special handling of appicon when irsaviewer is the firefly server.

- Post-joy UI, appIcon isn't a string (url), it's a react element. So **removed url handling code** which was causing type mismatch and failure to load irsaviewer from jupyter extension.
- Also **unset some styles** that are set by Irsaviewer becuase of its double banner layout, but in jupyter context, it's single banner.

## Testing

Build it locally following the instructions in readme and set https://irsa.ipac.caltech.edu/irsaviewer/ as `FIREFLY_URL`